### PR TITLE
Fix ipadCount bug

### DIFF
--- a/frontend/src/Order.tsx
+++ b/frontend/src/Order.tsx
@@ -46,7 +46,13 @@ const Order = () => {
 
     const isCreateDisabled = () => {
         return (
-            selectedOption === '' || selectedPerson === null || selectedExClass === '' || wbs === '' || address === '' || numberOfiPadsError
+            selectedOption === '' ||
+            selectedPerson === null ||
+            selectedExClass === '' ||
+            wbs === '' ||
+            address === '' ||
+            ipadCount === '' ||
+            numberOfiPadsError
         )
     }
 


### PR DESCRIPTION
Initial state of numberOfiPadsError is set to false to avoid having an error message before anything is typed. Needed to add check that the number of ipads isn't an empty string.

Closes #29 