### PR TITLE
Optimize cypress GH action test

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -50,7 +50,6 @@ jobs:
       - run: npm install
       - run: npm run build
 
-
   test_frontend:
     needs: check_files
     if: ${{ needs.check_files.outputs.file_match == 'true' }}
@@ -78,7 +77,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        
+
       - name: Run Prettier
         run: npm run prettier_check
 
@@ -93,17 +92,19 @@ jobs:
       - name: Start mock auth
         run: docker-compose -f docker-compose.cypress.yml up -d mock-auth
 
-      - name: Start frontend
-        run: docker-compose -f docker-compose.cypress.yml up -d frontend
-
       - name: Cypress run
         uses: cypress-io/github-action@v2
         with:
+          build: npm run build
+          start: npm start
+          wait-on: http://localhost:3000
           record: true
           tag: ${{ github.event_name }}
           working-directory: ./frontend
           config-file: cypress.json
-          env: FRONTEND_URL=http://localhost:3000,API_URL=http://localhost:5000,AUTH_URL=http://localhost:8080
         env:
+          FRONTEND_URL: http://localhost:3000
+          API_URL: http://localhost:5000
+          AUTH_URL: http://localhost:8080
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
Closes #185

Changed to use the built in functions of cypress github action to start the frontend, instead of starting it with docker. 
The cypress_run test now takes ~3.5 min, as opposed to 6-8 mins as before.

We could probably reduce it further by turning on parallelization. However, as we only have 2 specs, this is isn't that necessary yet. This would also mean the parallelized tests would have different names, meaning we would have to sort out our branch rules. 