### PR TITLE
Add health endpoint

### DIFF
--- a/backend/api/Controllers/iPadsController.cs
+++ b/backend/api/Controllers/iPadsController.cs
@@ -1,7 +1,7 @@
-﻿using Api.ActionFilters;
-using Api.Database;
+﻿using Api.Database;
 using Api.Database.Entities;
 using Api.Database.Models;
+using Api.Filters;
 using Api.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/backend/api/Filters/HealthCheckFilter.cs
+++ b/backend/api/Filters/HealthCheckFilter.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Api.Filters
+{
+    public class HealthCheckFilter : IDocumentFilter
+    {
+        public static readonly string HealthCheckEndpoint = "/health";
+
+        public void Apply(OpenApiDocument openApiDocument, DocumentFilterContext context)
+        {
+            var pathItem = new OpenApiPathItem
+            {
+                Summary = "Provides the health status for the public API"
+            };
+
+            var properties = new Dictionary<string, OpenApiSchema>
+            {
+                { "status", new OpenApiSchema() { Type = "string" } },
+                { "errors", new OpenApiSchema() { Type = "array" } }
+            };
+
+            var responseDefinition = new OpenApiMediaType
+            {
+                Schema = new OpenApiSchema
+                {
+                    Type = "object",
+                    AdditionalPropertiesAllowed = true,
+                    Properties = properties,
+                }
+            };
+
+            var responseOk = new OpenApiResponse();
+            responseOk.Content.Add("application/json", responseDefinition);
+            responseOk.Description = "The API is healthy and responsive";
+
+            var responseBad = new OpenApiResponse();
+            responseBad.Content.Add("application/json", responseDefinition);
+            responseBad.Description = "The API is unhealthy";
+
+            var operation = new OpenApiOperation
+            {
+                Summary = "Get the health status for the API",
+            };
+            operation.Tags.Add(new OpenApiTag { Name = "Health" });
+            operation.Responses.Add("200", responseOk);
+            operation.Responses.Add("401", new OpenApiResponse { Description = "Unauthorized" });
+            operation.Responses.Add("503", responseBad);
+
+            pathItem.AddOperation(OperationType.Get, operation);
+            openApiDocument?.Paths.Add(HealthCheckEndpoint, pathItem);
+        }
+    }
+}

--- a/backend/api/Filters/RBACAttribute.cs
+++ b/backend/api/Filters/RBACAttribute.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 
 
-namespace Api.ActionFilters
+namespace Api.Filters
 {
     public sealed class RBACAttribute : TypeFilterAttribute
     {

--- a/backend/api/Startup.cs
+++ b/backend/api/Startup.cs
@@ -158,6 +158,8 @@ namespace Api
             services.AddScoped<IPadDatabaseAccess, IPadDatabaseAccess>();
 
             services.AddApplicationInsightsTelemetry();
+
+            services.AddHealthChecks().AddDbContextCheck<DatabaseContext>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -188,6 +190,7 @@ namespace Api
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllers();
+                endpoints.MapHealthChecks("/health");
             });
         }
     }

--- a/backend/api/Startup.cs
+++ b/backend/api/Startup.cs
@@ -4,6 +4,7 @@ using Api.Controllers;
 using Api.Database;
 using Api.Database.Models;
 using Api.Extensions;
+using Api.Filters;
 using Api.Services;
 using Api.Utilities;
 using Equinor.TI.CommonLibrary.Client;
@@ -80,6 +81,8 @@ namespace Api
             #region Integrate Swagger
             services.AddSwaggerGen(c =>
             {
+                // Add documentation for health-endpoint
+                c.DocumentFilter<HealthCheckFilter>();
                 // Add implicit flow authentication to Swagger
                 c.AddSecurityDefinition("oauth2", new OpenApiSecurityScheme
                 {
@@ -190,7 +193,7 @@ namespace Api
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllers();
-                endpoints.MapHealthChecks("/health");
+                endpoints.MapHealthChecks(HealthCheckFilter.HealthCheckEndpoint);
             });
         }
     }

--- a/backend/api/api.csproj
+++ b/backend/api/api.csproj
@@ -21,9 +21,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.12" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.22" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.2" />
     <PackageReference Include="Microsoft.Identity.Web" Version="1.21.0" />
     <PackageReference Include="Equinor.TI.CommonLibrary.Client" Version="0.3.4" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.2.3" />


### PR DESCRIPTION
Closes #85 
The health endpoint only verifies the backend service itself and the database connection
There is no smooth way to add health endpoint to swagger doc, and this issue is not prioritized by the ASP.NET team